### PR TITLE
graphhopper 8

### DIFF
--- a/Dockerfile.graphhopper
+++ b/Dockerfile.graphhopper
@@ -1,4 +1,4 @@
-FROM openjdk:19 AS builder
+FROM amazoncorretto:21 AS builder
 
 # Fetch the graphhopper jar
 WORKDIR /routy

--- a/Dockerfile.graphhopper
+++ b/Dockerfile.graphhopper
@@ -2,7 +2,7 @@ FROM amazoncorretto:21 AS builder
 
 # Fetch the graphhopper jar
 WORKDIR /routy
-ADD https://repo1.maven.org/maven2/com/graphhopper/graphhopper-web/7.0/graphhopper-web-7.0.jar ./jars/graphhopper-web-7.0.jar
+ADD https://repo1.maven.org/maven2/com/graphhopper/graphhopper-web/8.0/graphhopper-web-8.0.jar ./jars/graphhopper-web-8.0.jar
 
 # Add the data
 ADD data/sweden.gtfs.zip data/sweden.gtfs.zip
@@ -11,7 +11,7 @@ ADD data/sweden-latest.osm.pbf data/sweden-latest.osm.pbf
 ADD config.routing.yml .
 
 # Import data and build graph
-RUN java -Xmx15g -Xms15g -jar jars/graphhopper-web-7.0.jar import config.routing.yml
+RUN java -Xmx15g -Xms15g -jar jars/graphhopper-web-8.0.jar import config.routing.yml
 
 # Run the server
-CMD ["java", "-Xmx15g", "-Xms15g", "-jar", "jars/graphhopper-web-7.0.jar", "server", "config.routing.yml"]
+CMD ["java", "-Xmx15g", "-Xms15g", "-jar", "jars/graphhopper-web-8.0.jar", "server", "config.routing.yml"]

--- a/config.routing.yml
+++ b/config.routing.yml
@@ -33,12 +33,10 @@ graphhopper:
   profiles:
     - name: foot
       vehicle: foot
-      weighting: fastest
+      custom_model_files: []
     - name: car
       vehicle: car
-      weighting: custom
-      custom_model:
-        distance_influence: 70
+      custom_model_files: []
 #      turn_costs: true
 #      u_turn_costs: 60
 
@@ -50,7 +48,7 @@ graphhopper:
 #      custom_model_file: bike.json
 
   # specify the folder where to find the custom model files
-  custom_models.directory: custom_models
+#  custom_models.directory: custom_models
 
   # Speed mode:
   # Its possible to speed up routing by doing a special graph preparation (Contraction Hierarchies, CH). This requires

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 services:
   routy:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile.graphhopper
     ports:
       - "8989:8989"
       - "8990:8990"
   tiles:
-    image: overv/openstreetmap-tile-server
+    image: overv/openstreetmap-tile-server:2.3.0
     volumes:
       - ./data/sweden-latest.osm.pbf:/data/region.osm.pbf
       - ./data/sweden.poly:/data/region.poly

--- a/index.html
+++ b/index.html
@@ -1,25 +1,30 @@
 <!DOCTYPE HTML>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
-    <style>
-      html, body {
-        height: 100%;
-        padding: 0;
-        margin: 0;
-      }
-      #map {
-        /* configure the size of the map */
-        width: 100%;
-        height: 100%;
-      }
-    </style>
-  </head>
-  <body>
-    <div id="map"></div>
-    <script src="script.js"></script>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+  <style>
+    html,
+    body {
+      height: 100%;
+      padding: 0;
+      margin: 0;
+    }
+
+    #map {
+      /* configure the size of the map */
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="map"></div>
+  <script src="script.js"></script>
+</body>
+
 </html>

--- a/script.js
+++ b/script.js
@@ -1,9 +1,9 @@
 // initialize Leaflet
-var map = L.map('map').setView({lon: 12.0, lat: 55.0}, 2);
+var map = L.map('map').setView({ lon: 12.0, lat: 55.0 }, 2);
 
 async function load_isochrone(lat_lon) {
   let hours = 1;
-  let time = 3600*hours;
+  let time = 3600 * hours;
   p = `${lat_lon.lat},${lat_lon.lng}`
   console.log(p);
   let url = new URL("http://localhost:8989/isochrone");
@@ -34,11 +34,11 @@ L.tileLayer(
 ).addTo(map);
 
 // show the scale bar on the lower left corner
-L.control.scale({imperial: false, metric: true}).addTo(map);
+L.control.scale({ imperial: false, metric: true }).addTo(map);
 
 // show a marker on the map
 L.marker(
-  {lon: 17.638936, lat: 59.858550}
+  { lon: 17.638936, lat: 59.858550 }
 ).bindPopup('The center of the world').addTo(map);
 
 //add_iso_to_map();
@@ -46,11 +46,11 @@ L.marker(
 var popup = L.popup();
 
 function onMapClick(e) {
-    popup
-        .setLatLng(e.latlng)
-        .setContent("You clicked the map at " + e.latlng.toString())
-        .openOn(map);
-    add_iso_to_map(e.latlng)
+  popup
+    .setLatLng(e.latlng)
+    .setContent("You clicked the map at " + e.latlng.toString())
+    .openOn(map);
+  add_iso_to_map(e.latlng)
 }
 
 map.on('click', onMapClick);

--- a/script.js
+++ b/script.js
@@ -27,7 +27,7 @@ async function add_iso_to_map(lat_lon) {
 
 // add the OpenStreetMap tiles
 L.tileLayer(
-  'http://127.0.0.1:8080/tile/{z}/{x}/{y}.png',
+  'http://localhost:8080/tile/{z}/{x}/{y}.png',
   {
     attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
   }

--- a/scripts/fetch_gtfs.sh
+++ b/scripts/fetch_gtfs.sh
@@ -15,7 +15,7 @@ fi
 
 # Download the data
 url="https://opendata.samtrafiken.se/gtfs-sweden/sweden.zip?key=${KARTA_GTFS_KEY}"
-curl --location -o data/sweden.gtfs.zip "$url"
+curl --location --output data/sweden.gtfs.zip --header "Accept-Encoding: gzip" "$url"
 
 # Check we don't have an acces denied error in the response
 if grep -q "access denied" data/sweden.gtfs.zip; then


### PR DESCRIPTION
- Stop using deprecated openjdk as base image
- Use graphhopper 8
- Pin tile server version
- Use localhost as 127.0.0.1 gives 404
- gtfs endpoint now requires accept-encoding:gzip header
- Format
